### PR TITLE
Update metadata to point to WICG

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Compression Streams
 Shortname: compression
 Level: none
-Status: w3c/CG-DRAFT
+Status: CG-DRAFT
 Group: wicg
 ED: https://wicg.github.io/compression/
 Editor: Canon Mukai, Google

--- a/index.bs
+++ b/index.bs
@@ -4,20 +4,19 @@ Shortname: compression
 Level: none
 Status: w3c/CG-DRAFT
 Group: wicg
-ED: https://ricea.github.io/compression/
+ED: https://wicg.github.io/compression/
 Editor: Canon Mukai, Google
 Editor: Adam Rice, Google
 Abstract:
   This document defines a set of JavaScript APIs to compress and decompress
   streams of binary data.
-Repository: ricea/compression-streams
+Repository: wicg/compression
 Indent: 2
 Markup Shorthands: markdown yes
 Boilerplate: omit conformance
 </pre>
 <pre class="link-defaults">
 spec:streams; type:interface; text:ReadableStream
-spec:html; type:dfn; for:/; text:origin
 </pre>
 <pre class="anchors">
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
@@ -27,7 +26,6 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: pending; url: sec-promise-objects
     text: resolved; url: sec-promise-objects
     text: settled; url: sec-promise-objects
-
 </pre>
 
 # Introduction #    {#introduction}

--- a/index.html
+++ b/index.html
@@ -1214,8 +1214,8 @@ Possible extra rowspan handling
 </style>
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version e86d5b1b47a216fa66165c234892adc259212183" name="generator">
-  <link href="https://ricea.github.io/compression/" rel="canonical">
-  <meta content="a69075cf33884d94c9aeb828123c0638136f3ed7" name="document-revision">
+  <link href="https://wicg.github.io/compression/" rel="canonical">
+  <meta content="1afe353584e675a9847aad9b82c9d689c3a2fecb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1466,9 +1466,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
-     <dd><a class="u-url" href="https://ricea.github.io/compression/">https://ricea.github.io/compression/</a>
+     <dd><a class="u-url" href="https://wicg.github.io/compression/">https://wicg.github.io/compression/</a>
      <dt>Issue Tracking:
-     <dd><a href="https://github.com/ricea/compression-streams/issues/">GitHub</a>
+     <dd><a href="https://github.com/wicg/compression/issues/">GitHub</a>
      <dt class="editor">Editors:
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Canon Mukai</span> (<span class="p-org org">Google</span>)
      <dd class="editor p-author h-card vcard"><span class="p-name fn">Adam Rice</span> (<span class="p-org org">Google</span>)

--- a/index.html
+++ b/index.html
@@ -1215,7 +1215,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version e86d5b1b47a216fa66165c234892adc259212183" name="generator">
   <link href="https://wicg.github.io/compression/" rel="canonical">
-  <meta content="1afe353584e675a9847aad9b82c9d689c3a2fecb" name="document-revision">
+  <meta content="0b0ed2deb2d409d14760c5578d9cf5258b6b9899" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1462,7 +1462,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Compression Streams</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-27">27 November 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-28">28 November 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:


### PR DESCRIPTION
Change self-links and Github links to point to the WICG version of the
specification.

Also remove an unused link-defaults reference to the HTML standard.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/compression/pull/21.html" title="Last updated on Nov 28, 2019, 4:33 AM UTC (8af1965)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compression/21/85b3211...8af1965.html" title="Last updated on Nov 28, 2019, 4:33 AM UTC (8af1965)">Diff</a>