### PR TITLE
Avoid JS keyword in example

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -189,4 +189,4 @@ utility of the API:
 ## References & acknowledgements
 
 Original text by Canon Mukai with contributions from Adam Rice, Domenic
-Denicola, Takeshi Yoshino and Yutaka Hirano.
+Denicola, Jake Archibald, Takeshi Yoshino and Yutaka Hirano.

--- a/explainer.md
+++ b/explainer.md
@@ -96,10 +96,10 @@ const compressedReadableStream = inputReadableStream.pipeThrough(new Compression
 ### Deflate-compress an ArrayBuffer to a Uint8Array
 
 ```javascript
-async function compressArrayBuffer(in) {
+async function compressArrayBuffer(data) {
   const cs = new CompressionStream('deflate');
   const writer = cs.writable.getWriter();
-  writer.write(in);
+  writer.write(data);
   writer.close();
   const out = [];
   const reader = cs.readable.getReader();


### PR DESCRIPTION
The compressArrayBuffer() example uses "in" as a variable name. This
doesn't work because "in" is a keyword. Rename it to "data".