### PR TITLE
Typo fix

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,7 +32,7 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
 
 *This section is non-normative.*
 
-The APIs specified in this specification are used to compress and decompress streams of data. They support "deflate" and "gzip" as compression algorithms. They are widely used in web developers.
+The APIs specified in this specification are used to compress and decompress streams of data. They support "deflate" and "gzip" as compression algorithms. They are widely used by web developers.
 
 # Conformance #  {#conformance}
 

--- a/index.html
+++ b/index.html
@@ -1546,7 +1546,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <main>
    <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
    <p><em>This section is non-normative.</em></p>
-   <p>The APIs specified in this specification are used to compress and decompress streams of data. They support "deflate" and "gzip" as compression algorithms. They are widely used in web developers.</p>
+   <p>The APIs specified in this specification are used to compress and decompress streams of data. They support "deflate" and "gzip" as compression algorithms. They are widely used by web developers.</p>
    <h2 class="heading settled" data-level="2" id="conformance"><span class="secno">2. </span><span class="content">Conformance</span><a class="self-link" href="#conformance"></a></h2>
    <p>As well as sections marked as non-normative, all authoring guidelines,
 diagrams, examples, and notes in this specification are non-normative.


### PR DESCRIPTION
> They are widely used in web developers.

Not sure if this was supposed to say "in web development" or "by web developers", I changed it to the latter.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Malvoz/compression/pull/33.html" title="Last updated on May 20, 2020, 7:48 PM UTC (be1dce2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compression/33/3705d4c...Malvoz:be1dce2.html" title="Last updated on May 20, 2020, 7:48 PM UTC (be1dce2)">Diff</a>