### PR TITLE
Style the note about the naming of "deflate"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -69,7 +69,8 @@ A <dfn>compression context</dfn> is the internal state maintained by a compressi
 : `deflate`
 :: "ZLIB Compressed Data Format" [[!RFC1950]]
 
-   * This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See [[RFC7230]] section 4.2.2.
+   Note: This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See [[RFC7230]] section 4.2.2.
+
    * Implementations must be "compliant" as described in [[!RFC1950]] section 2.3.
    * Field values described as invalid in [[!RFC1950]] must not be created by CompressionStream, and are errors for DecompressionStream.
    * The only valid value of the `CM` (Compression method) part of the `CMF` field is 8.

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
   <title>Compression Streams</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
-  <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version b94c7e755, updated Fri Feb 19 16:28:59 2021 -0800" name="generator">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version dfbc2b297, updated Thu Nov 11 15:52:32 2021 -0800" name="generator">
   <link href="https://wicg.github.io/compression/" rel="canonical">
 <style>/* style-autolinks */
 
@@ -112,9 +112,9 @@ pre .property::before, pre .property::after {
     --ins-bg: transparent;
 
     --a-normal-text: #034575;
-    --a-normal-underline: #707070;
+    --a-normal-underline: #bbb;
     --a-visited-text: var(--a-normal-text);
-    --a-visited-underline: #bbb;
+    --a-visited-underline: #707070;
     --a-hover-bg: rgba(75%, 75%, 75%, .25);
     --a-active-text: #c00;
     --a-active-underline: #c00;
@@ -247,6 +247,16 @@ figcaption:not(.no-marker)::before {
 
 .dfn-paneled { cursor: pointer; }
 </style>
+<style>/* style-issues */
+
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -257,6 +267,62 @@ figcaption:not(.no-marker)::before {
 [data-md] > :last-child {
     margin-bottom: 0;
 }</style>
+<style>/* style-mdn-anno */
+
+            @media (max-width: 767px) { .mdn-anno { opacity: .1 } }
+            .mdn-anno { font: 1em sans-serif; padding: 0.3em; position: absolute; z-index: 8; right: 0.3em; background: #EEE; color: black; box-shadow: 0 0 3px #999; overflow: hidden; border-collapse: initial; border-spacing: initial; min-width: 9em; max-width: min-content; white-space: nowrap; word-wrap: normal; hyphens: none}
+            .mdn-anno:not(.wrapped) { opacity: 1}
+            .mdn-anno:hover { z-index: 9 }
+            .mdn-anno.wrapped { min-width: 0 }
+            .mdn-anno.wrapped > :not(button) { display: none; }
+            .mdn-anno > .mdn-anno-btn { cursor: pointer; border: none; color: #000; background: transparent; margin: -8px; float: right; padding: 10px 8px 8px 8px; outline: none; }
+            .mdn-anno > .mdn-anno-btn > .less-than-two-engines-flag { color: red; padding-right: 2px; }
+            .mdn-anno > .mdn-anno-btn > .all-engines-flag { color: green; padding-right: 2px; }
+            .mdn-anno > .mdn-anno-btn > span { color: #fff; background-color: #000; font-weight: normal; font-family: zillaslab, Palatino, "Palatino Linotype", serif; padding: 2px 3px 0px 3px; line-height: 1.3em; vertical-align: top; }
+            .mdn-anno > .feature { margin-top: 20px; }
+            .mdn-anno > .feature:not(:first-of-type) { border-top: 1px solid #999; margin-top: 6px; padding-top: 2px; }
+            .mdn-anno > .feature > .less-than-two-engines-text { color: red }
+            .mdn-anno > .feature > .all-engines-text { color: green }
+            .mdn-anno > .feature > p { font-size: .75em; margin-top: 6px; margin-bottom: 0; }
+            .mdn-anno > .feature > p + p { margin-top: 3px; }
+            .mdn-anno > .feature > .support { display: block; font-size: 0.6em; margin: 0; padding: 0; margin-top: 2px }
+            .mdn-anno > .feature > .support + div { padding-top: 0.5em; }
+            .mdn-anno > .feature > .support > hr { display: block; border: none; border-top: 1px dotted #999; padding: 3px 0px 0px 0px; margin: 2px 3px 0px 3px; }
+            .mdn-anno > .feature > .support > hr::before { content: ""; }
+            .mdn-anno > .feature > .support > span { padding: 0.2em 0; display: block; display: table; }
+            .mdn-anno > .feature > .support > span.no { color: #CCCCCC; filter: grayscale(100%); }
+            .mdn-anno > .feature > .support > span.no::before { opacity: 0.5; }
+            .mdn-anno > .feature > .support > span:first-of-type { padding-top: 0.5em; }
+            .mdn-anno > .feature > .support > span > span { padding: 0 0.5em; display: table-cell; }
+            .mdn-anno > .feature > .support > span > span:first-child { width: 100%; }
+            .mdn-anno > .feature > .support > span > span:last-child { width: 100%; white-space: pre; padding: 0; }
+            .mdn-anno > .feature > .support > span::before { content: ' '; display: table-cell; min-width: 1.5em; height: 1.5em; background: no-repeat center center; background-size: contain; text-align: right; font-size: 0.75em; font-weight: bold; }
+            .mdn-anno > .feature > .support > .chrome_android::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+            .mdn-anno > .feature > .support > .firefox_android::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+            .mdn-anno > .feature > .support > .chrome::before { background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg); }
+            .mdn-anno > .feature > .support > .edge_blink::before { background-image: url(https://resources.whatwg.org/browser-logos/edge.svg); }
+            .mdn-anno > .feature > .support > .edge::before { background-image: url(https://resources.whatwg.org/browser-logos/edge_legacy.svg); }
+            .mdn-anno > .feature > .support > .firefox::before { background-image: url(https://resources.whatwg.org/browser-logos/firefox.png); }
+            .mdn-anno > .feature > .support > .ie::before { background-image: url(https://resources.whatwg.org/browser-logos/ie.png); }
+            .mdn-anno > .feature > .support > .safari_ios::before { background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg); }
+            .mdn-anno > .feature > .support > .nodejs::before { background-image: url(https://nodejs.org/static/images/favicons/favicon.ico); }
+            .mdn-anno > .feature > .support > .opera_android::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+            .mdn-anno > .feature > .support > .opera::before { background-image: url(https://resources.whatwg.org/browser-logos/opera.svg); }
+            .mdn-anno > .feature > .support > .safari::before { background-image: url(https://resources.whatwg.org/browser-logos/safari.png); }
+            .mdn-anno > .feature > .support > .samsunginternet_android::before { background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg); }
+            .mdn-anno > .feature > .support > .webview_android::before { background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png); }
+            .name-slug-mismatch { color: red }
+            .caniuse-status:hover { z-index: 9; }
+
+            /* dt, li, .issue, .note, and .example are "position: relative", so to put annotation at right margin, must move to right of containing block */
+            .h-entry:not(.status-LS) dt > .mdn-anno, .h-entry:not(.status-LS) li > .mdn-anno, .h-entry:not(.status-LS) .issue > .mdn-anno, .h-entry:not(.status-LS) .note > .mdn-anno, .h-entry:not(.status-LS) .example > .mdn-anno { right: -6.7em; }
+            .h-entry p + .mdn-anno { margin-top: 0; }
+            h2 + .mdn-anno.after { margin: -48px 0 0 0; }
+            h3 + .mdn-anno.after { margin: -46px 0 0 0; }
+            h4 + .mdn-anno.after { margin: -42px 0 0 0; }
+            h5 + .mdn-anno.after { margin: -40px 0 0 0; }
+            h6 + .mdn-anno.after { margin: -40px 0 0 0; }
+            </style>
 <style>/* style-selflinks */
 
 :root {
@@ -564,9 +630,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Compression Streams</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-03-31">31 March 2021</time></span></h2>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2021-11-15">15 November 2021</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -654,7 +720,7 @@ specification MUST implement them in a manner consistent with the ECMAScript
 Bindings defined in the Web IDL specification <a data-link-type="biblio" href="#biblio-webidl">[WebIDL]</a>, as this
 specification uses that specification and terminology.</p>
    <h2 class="heading settled" data-level="3" id="terminology"><span class="secno">3. </span><span class="content">Terminology</span><a class="self-link" href="#terminology"></a></h2>
-   <p>A chunk is a piece of data. In the case of CompressionStream and DecompressionStream, the output chunk type is Uint8Array. They accept any <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource">BufferSource</a></code> type as input.</p>
+   <p>A chunk is a piece of data. In the case of CompressionStream and DecompressionStream, the output chunk type is Uint8Array. They accept any <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource">BufferSource</a></code> type as input.</p>
    <p>A stream represents an ordered sequence of chunks. The terms <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream">ReadableStream</a></code> and <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#writablestream" id="ref-for-writablestream">WritableStream</a></code> are defined in <a data-link-type="biblio" href="#biblio-whatwg-streams">[WHATWG-STREAMS]</a>.</p>
    <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compression-context">compression context</dfn> is the internal state maintained by a compression or decompression algorithm. The contents of a <a data-link-type="dfn" href="#compression-context" id="ref-for-compression-context">compression context</a> depend on the format, algorithm and implementation in use. From the point of view of this specification, it is an opaque object. A <a data-link-type="dfn" href="#compression-context" id="ref-for-compression-context①">compression context</a> is initially in a start state such that it anticipates the first byte of input.</p>
    <h2 class="heading settled" data-level="4" id="supported-formats"><span class="secno">4. </span><span class="content">Supported formats</span><a class="self-link" href="#supported-formats"></a></h2>
@@ -662,9 +728,8 @@ specification uses that specification and terminology.</p>
     <dt data-md><code>deflate</code>
     <dd data-md>
      <p>"ZLIB Compressed Data Format" <a data-link-type="biblio" href="#biblio-rfc1950">[RFC1950]</a></p>
+     <p class="note" role="note"><span>Note:</span> This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> section 4.2.2.</p>
      <ul>
-      <li data-md>
-       <p>This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> section 4.2.2.</p>
       <li data-md>
        <p>Implementations must be "compliant" as described in <a data-link-type="biblio" href="#biblio-rfc1950">[RFC1950]</a> section 2.3.</p>
       <li data-md>
@@ -707,40 +772,72 @@ specification uses that specification and terminology.</p>
      </ul>
    </dl>
    <h2 class="heading settled" data-level="5" id="compression-stream"><span class="secno">5. </span><span class="content">Interface <code>CompressionStream</code></span><a class="self-link" href="#compression-stream"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream" title="The CompressionStream interface of the Compression Streams API is an API for compressing a stream of data.">CompressionStream</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="compressionstream"><code><c- g>CompressionStream</c-></code></dfn> {
-  <a class="idl-code" data-link-type="constructor" href="#dom-compressionstream-compressionstream" id="ref-for-dom-compressionstream-compressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CompressionStream/CompressionStream(format), CompressionStream/constructor(format)" data-dfn-type="argument" data-export id="dom-compressionstream-compressionstream-format-format"><code><c- g>format</c-></code><a class="self-link" href="#dom-compressionstream-compressionstream-format-format"></a></dfn>);
+  <a class="idl-code" data-link-type="constructor" href="#dom-compressionstream-compressionstream" id="ref-for-dom-compressionstream-compressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="CompressionStream/CompressionStream(format), CompressionStream/constructor(format)" data-dfn-type="argument" data-export id="dom-compressionstream-compressionstream-format-format"><code><c- g>format</c-></code><a class="self-link" href="#dom-compressionstream-compressionstream-format-format"></a></dfn>);
 };
 <a data-link-type="idl-name" href="#compressionstream" id="ref-for-compressionstream"><c- n>CompressionStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream" id="ref-for-generictransformstream"><c- n>GenericTransformStream</c-></a>;
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#compressionstream" id="ref-for-compressionstream①">CompressionStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="CompressionStream" data-dfn-type="dfn" data-noexport id="compressionstream-format">format</dfn> and <a data-link-type="dfn" href="#compression-context" id="ref-for-compression-context②">compression context</a> <dfn class="dfn-paneled" data-dfn-for="CompressionStream" data-dfn-type="dfn" data-noexport id="compressionstream-context">context</dfn>.</p>
+   <div class="mdn-anno wrapped">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream/CompressionStream" title="The CompressionStream() constructor creates a new CompressionStream object which compresses a stream of data.">CompressionStream/CompressionStream</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+     </div>
+    </div>
+   </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="CompressionStream" data-dfn-type="constructor" data-export data-lt="CompressionStream(format)|constructor(format)" id="dom-compressionstream-compressionstream"><code>new CompressionStream(<var>format</var>)</code></dfn> steps are:</p>
    <ol>
     <li data-md>
-     <p>If <em>format</em> is unsupported in <code class="idl"><a data-link-type="idl" href="#compressionstream" id="ref-for-compressionstream②">CompressionStream</a></code>, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code>.</p>
+     <p>If <em>format</em> is unsupported in <code class="idl"><a data-link-type="idl" href="#compressionstream" id="ref-for-compressionstream②">CompressionStream</a></code>, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror">TypeError</a></code>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this">this</a>'s <a data-link-type="dfn" href="#compressionstream-format" id="ref-for-compressionstream-format">format</a> to <em>format</em>.</p>
+     <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this">this</a>'s <a data-link-type="dfn" href="#compressionstream-format" id="ref-for-compressionstream-format">format</a> to <em>format</em>.</p>
     <li data-md>
-     <p>Let <em>transformAlgorithm</em> be an algorithm which takes a <em>chunk</em> argument and runs the <a data-link-type="dfn" href="#compress-and-enqueue-a-chunk" id="ref-for-compress-and-enqueue-a-chunk">compress and enqueue a chunk</a> algorithm with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this①">this</a> and <em>chunk</em>.</p>
+     <p>Let <em>transformAlgorithm</em> be an algorithm which takes a <em>chunk</em> argument and runs the <a data-link-type="dfn" href="#compress-and-enqueue-a-chunk" id="ref-for-compress-and-enqueue-a-chunk">compress and enqueue a chunk</a> algorithm with <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this①">this</a> and <em>chunk</em>.</p>
     <li data-md>
-     <p>Let <em>flushAlgorithm</em> be an algorithm which takes no argument and runs the <a data-link-type="dfn" href="#compress-flush-and-enqueue" id="ref-for-compress-flush-and-enqueue">compress flush and enqueue</a> algorithm with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this②">this</a>.</p>
+     <p>Let <em>flushAlgorithm</em> be an algorithm which takes no argument and runs the <a data-link-type="dfn" href="#compress-flush-and-enqueue" id="ref-for-compress-flush-and-enqueue">compress flush and enqueue</a> algorithm with <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this②">this</a>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this③">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform">transform</a> to a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#new" id="ref-for-new">new</a> <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#transformstream" id="ref-for-transformstream">TransformStream</a></code>.</p>
+     <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this③">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform">transform</a> to a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new">new</a> <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#transformstream" id="ref-for-transformstream">TransformStream</a></code>.</p>
     <li data-md>
-     <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up" id="ref-for-transformstream-set-up">Set up</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this④">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform①">transform</a> with <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm" id="ref-for-transformstream-set-up-transformalgorithm">transformAlgorithm</a></i> set to <em>transformAlgorithm</em> and <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm" id="ref-for-transformstream-set-up-flushalgorithm">flushAlgorithm</a></i> set to <em>flushAlgorithm</em>.</p>
+     <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up" id="ref-for-transformstream-set-up">Set up</a> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this④">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform①">transform</a> with <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm" id="ref-for-transformstream-set-up-transformalgorithm">transformAlgorithm</a></i> set to <em>transformAlgorithm</em> and <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm" id="ref-for-transformstream-set-up-flushalgorithm">flushAlgorithm</a></i> set to <em>flushAlgorithm</em>.</p>
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compress-and-enqueue-a-chunk">compress and enqueue a chunk</dfn> algorithm, given a <code class="idl"><a data-link-type="idl" href="#compressionstream" id="ref-for-compressionstream③">CompressionStream</a></code> object <em>cs</em> and a <em>chunk</em>, runs these steps:</p>
    <ol>
     <li data-md>
-     <p>If <em>chunk</em> is not a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource①">BufferSource</a></code> type, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>.</p>
+     <p>If <em>chunk</em> is not a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource①">BufferSource</a></code> type, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror①">TypeError</a></code>.</p>
     <li data-md>
      <p>Let <em>buffer</em> be the result of compressing <em>chunk</em> with <em>cs</em>'s <a data-link-type="dfn" href="#compressionstream-format" id="ref-for-compressionstream-format①">format</a> and <a data-link-type="dfn" href="#compressionstream-context" id="ref-for-compressionstream-context">context</a>.</p>
     <li data-md>
      <p>If <em>buffer</em> is empty, return.</p>
     <li data-md>
-     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s.</p>
+     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array">Uint8Array</a></code>s.</p>
     <li data-md>
-     <p>For each <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue">enqueue</a> <em>array</em> in <em>cs</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform②">transform</a>.</p>
+     <p>For each <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array①">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue">enqueue</a> <em>array</em> in <em>cs</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform②">transform</a>.</p>
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="compress-flush-and-enqueue">compress flush and enqueue</dfn> algorithm, which handles the end of data from the input <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream①">ReadableStream</a></code> object, given a <code class="idl"><a data-link-type="idl" href="#compressionstream" id="ref-for-compressionstream④">CompressionStream</a></code> object <em>cs</em>, runs these steps:</p>
    <ol>
@@ -749,58 +846,90 @@ specification uses that specification and terminology.</p>
     <li data-md>
      <p>If <em>buffer</em> is empty, return.</p>
     <li data-md>
-     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array②">Uint8Array</a></code>s.</p>
+     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array②">Uint8Array</a></code>s.</p>
     <li data-md>
-     <p>For each <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array③">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue①">enqueue</a> <em>array</em> in <em>cs</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform③">transform</a>.</p>
+     <p>For each <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array③">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue①">enqueue</a> <em>array</em> in <em>cs</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform③">transform</a>.</p>
    </ol>
    <h2 class="heading settled" data-level="6" id="decompression-stream"><span class="secno">6. </span><span class="content">Interface <code>DecompressionStream</code></span><a class="self-link" href="#decompression-stream"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+   <div class="mdn-anno wrapped after">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream" title="The DecompressionStream interface of the Compression Streams API is an API for decompressing a stream of data.">DecompressionStream</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+     </div>
+    </div>
+   </div>
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="interface" data-export id="decompressionstream"><code><c- g>DecompressionStream</c-></code></dfn> {
-  <a class="idl-code" data-link-type="constructor" href="#dom-decompressionstream-decompressionstream" id="ref-for-dom-decompressionstream-decompressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="DecompressionStream/DecompressionStream(format), DecompressionStream/constructor(format)" data-dfn-type="argument" data-export id="dom-decompressionstream-decompressionstream-format-format"><code><c- g>format</c-></code><a class="self-link" href="#dom-decompressionstream-decompressionstream-format-format"></a></dfn>);
+  <a class="idl-code" data-link-type="constructor" href="#dom-decompressionstream-decompressionstream" id="ref-for-dom-decompressionstream-decompressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString①"><c- b>DOMString</c-></a> <dfn class="idl-code" data-dfn-for="DecompressionStream/DecompressionStream(format), DecompressionStream/constructor(format)" data-dfn-type="argument" data-export id="dom-decompressionstream-decompressionstream-format-format"><code><c- g>format</c-></code><a class="self-link" href="#dom-decompressionstream-decompressionstream-format-format"></a></dfn>);
 };
 <a data-link-type="idl-name" href="#decompressionstream" id="ref-for-decompressionstream"><c- n>DecompressionStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream" id="ref-for-generictransformstream①"><c- n>GenericTransformStream</c-></a>;
 </pre>
    <p>A <code class="idl"><a data-link-type="idl" href="#decompressionstream" id="ref-for-decompressionstream①">DecompressionStream</a></code> has an associated <dfn class="dfn-paneled" data-dfn-for="DecompressionStream" data-dfn-type="dfn" data-noexport id="decompressionstream-format">format</dfn> and <a data-link-type="dfn" href="#compression-context" id="ref-for-compression-context③">compression context</a> <dfn class="dfn-paneled" data-dfn-for="DecompressionStream" data-dfn-type="dfn" data-noexport id="decompressionstream-context">context</dfn>.</p>
+   <div class="mdn-anno wrapped">
+    <button class="mdn-anno-btn"><b class="less-than-two-engines-flag" title="This feature is in less than two current engines.">⚠</b><span>MDN</span></button>
+    <div class="feature">
+     <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/DecompressionStream" title="The DecompressionStream() constructor creates a new DecompressionStream object which decompresses a stream of data.">DecompressionStream/DecompressionStream</a></p>
+     <p class="less-than-two-engines-text">In only one current engine.</p>
+     <div class="support">
+      <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
+      <hr>
+      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <hr>
+      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <hr>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+     </div>
+    </div>
+   </div>
    <p>The <dfn class="dfn-paneled idl-code" data-dfn-for="DecompressionStream" data-dfn-type="constructor" data-export data-lt="DecompressionStream(format)|constructor(format)" id="dom-decompressionstream-decompressionstream"><code>new DecompressionStream(<var>format</var>)</code></dfn> steps are:</p>
    <ol>
     <li data-md>
-     <p>If <em>format</em> is unsupported in <code class="idl"><a data-link-type="idl" href="#decompressionstream" id="ref-for-decompressionstream②">DecompressionStream</a></code>, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code>.</p>
+     <p>If <em>format</em> is unsupported in <code class="idl"><a data-link-type="idl" href="#decompressionstream" id="ref-for-decompressionstream②">DecompressionStream</a></code>, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror②">TypeError</a></code>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this⑤">this</a>'s <a data-link-type="dfn" href="#decompressionstream-format" id="ref-for-decompressionstream-format">format</a> to <em>format</em>.</p>
+     <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑤">this</a>'s <a data-link-type="dfn" href="#decompressionstream-format" id="ref-for-decompressionstream-format">format</a> to <em>format</em>.</p>
     <li data-md>
-     <p>Let <em>transformAlgorithm</em> be an algorithm which takes a <em>chunk</em> argument and runs the <a data-link-type="dfn" href="#decompress-and-enqueue-a-chunk" id="ref-for-decompress-and-enqueue-a-chunk">decompress and enqueue a chunk</a> algorithm with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this⑥">this</a> and <em>chunk</em>.</p>
+     <p>Let <em>transformAlgorithm</em> be an algorithm which takes a <em>chunk</em> argument and runs the <a data-link-type="dfn" href="#decompress-and-enqueue-a-chunk" id="ref-for-decompress-and-enqueue-a-chunk">decompress and enqueue a chunk</a> algorithm with <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑥">this</a> and <em>chunk</em>.</p>
     <li data-md>
-     <p>Let <em>flushAlgorithm</em> be an algorithm which takes no argument and runs the <a data-link-type="dfn" href="#decompress-flush-and-enqueue" id="ref-for-decompress-flush-and-enqueue">decompress flush and enqueue</a> algorithm with <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this⑦">this</a>.</p>
+     <p>Let <em>flushAlgorithm</em> be an algorithm which takes no argument and runs the <a data-link-type="dfn" href="#decompress-flush-and-enqueue" id="ref-for-decompress-flush-and-enqueue">decompress flush and enqueue</a> algorithm with <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑦">this</a>.</p>
     <li data-md>
-     <p>Set <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this⑧">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform④">transform</a> to a <a data-link-type="dfn" href="https://heycam.github.io/webidl/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#transformstream" id="ref-for-transformstream①">TransformStream</a></code>.</p>
+     <p>Set <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑧">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform④">transform</a> to a <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#new" id="ref-for-new①">new</a> <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#transformstream" id="ref-for-transformstream①">TransformStream</a></code>.</p>
     <li data-md>
-     <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up" id="ref-for-transformstream-set-up①">Set up</a> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#this" id="ref-for-this⑨">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑤">transform</a> with <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm" id="ref-for-transformstream-set-up-transformalgorithm①">transformAlgorithm</a></i> set to <em>transformAlgorithm</em> and <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm" id="ref-for-transformstream-set-up-flushalgorithm①">flushAlgorithm</a></i> set to <em>flushAlgorithm</em>.</p>
+     <p><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up" id="ref-for-transformstream-set-up①">Set up</a> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#this" id="ref-for-this⑨">this</a>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑤">transform</a> with <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm" id="ref-for-transformstream-set-up-transformalgorithm①">transformAlgorithm</a></i> set to <em>transformAlgorithm</em> and <i><a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm" id="ref-for-transformstream-set-up-flushalgorithm①">flushAlgorithm</a></i> set to <em>flushAlgorithm</em>.</p>
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="decompress-and-enqueue-a-chunk">decompress and enqueue a chunk</dfn> algorithm, given a <code class="idl"><a data-link-type="idl" href="#decompressionstream" id="ref-for-decompressionstream③">DecompressionStream</a></code> object <em>ds</em> and a <em>chunk</em>, runs these steps:</p>
    <ol>
     <li data-md>
-     <p>If <em>chunk</em> is not a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#BufferSource" id="ref-for-BufferSource②">BufferSource</a></code> type, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror③">TypeError</a></code>.</p>
+     <p>If <em>chunk</em> is not a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#BufferSource" id="ref-for-BufferSource②">BufferSource</a></code> type, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror③">TypeError</a></code>.</p>
     <li data-md>
-     <p>Let <em>buffer</em> be the result of decompressing <em>chunk</em> with <em>ds</em>'s <a data-link-type="dfn" href="#decompressionstream-format" id="ref-for-decompressionstream-format①">format</a> and <a data-link-type="dfn" href="#decompressionstream-context" id="ref-for-decompressionstream-context">context</a>. If this results in an error, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code>.</p>
+     <p>Let <em>buffer</em> be the result of decompressing <em>chunk</em> with <em>ds</em>'s <a data-link-type="dfn" href="#decompressionstream-format" id="ref-for-decompressionstream-format①">format</a> and <a data-link-type="dfn" href="#decompressionstream-context" id="ref-for-decompressionstream-context">context</a>. If this results in an error, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror④">TypeError</a></code>.</p>
     <li data-md>
      <p>If <em>buffer</em> is empty, return.</p>
     <li data-md>
-     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array④">Uint8Array</a></code>s.</p>
+     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array④">Uint8Array</a></code>s.</p>
     <li data-md>
-     <p>For each <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑤">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue②">enqueue</a> <em>array</em> in <em>ds</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑥">transform</a>.</p>
+     <p>For each <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑤">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue②">enqueue</a> <em>array</em> in <em>ds</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑥">transform</a>.</p>
    </ol>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="decompress-flush-and-enqueue">decompress flush and enqueue</dfn> algorithm, which handles the end of data from the input <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream" id="ref-for-readablestream②">ReadableStream</a></code> object, given a <code class="idl"><a data-link-type="idl" href="#decompressionstream" id="ref-for-decompressionstream④">DecompressionStream</a></code> object <em>ds</em>, runs these steps:</p>
    <ol>
     <li data-md>
      <p>Let <em>buffer</em> be the result of decompressing an empty input with <em>ds</em>'s <a data-link-type="dfn" href="#decompressionstream-format" id="ref-for-decompressionstream-format②">format</a> and <a data-link-type="dfn" href="#decompressionstream-context" id="ref-for-decompressionstream-context①">context</a>, with the finish flag.</p>
     <li data-md>
-     <p>If the end of the compressed input has not been reached, then throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code>.</p>
+     <p>If the end of the compressed input has not been reached, then throw a <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror" id="ref-for-exceptiondef-typeerror⑤">TypeError</a></code>.</p>
     <li data-md>
      <p>If <em>buffer</em> is empty, return.</p>
     <li data-md>
-     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑥">Uint8Array</a></code>s.</p>
+     <p>Split <em>buffer</em> into one or more non-empty pieces and convert them into <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑥">Uint8Array</a></code>s.</p>
     <li data-md>
-     <p>For each <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑦">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue③">enqueue</a> <em>array</em> in <em>ds</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑦">transform</a>.</p>
+     <p>For each <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-Uint8Array" id="ref-for-idl-Uint8Array⑦">Uint8Array</a></code> <em>array</em>, <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#transformstream-enqueue" id="ref-for-transformstream-enqueue③">enqueue</a> <em>array</em> in <em>ds</em>'s <a data-link-type="dfn" href="https://streams.spec.whatwg.org/#generictransformstream-transform" id="ref-for-generictransformstream-transform⑦">transform</a>.</p>
    </ol>
    <h2 class="heading settled" data-level="7" id="privacy-security"><span class="secno">7. </span><span class="content">Privacy and Security Considerations</span><a class="self-link" href="#privacy-security"></a></h2>
    <p>The API doesn’t add any new privileges to the web platform.</p>
@@ -845,40 +974,40 @@ specification uses that specification and terminology.</p>
    <h2 class="heading settled" data-level="9" id="acknowledgments"><span class="secno">9. </span><span class="content">Acknowledgments</span><a class="self-link" href="#acknowledgments"></a></h2>
     The editors wish to thank Domenic Denicola and Yutaka Hirano, for their support. 
   </main>
-<script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+<script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
-   <li><a href="#compress-and-enqueue-a-chunk">compress and enqueue a chunk</a><span>, in §5</span>
-   <li><a href="#compress-flush-and-enqueue">compress flush and enqueue</a><span>, in §5</span>
-   <li><a href="#compression-context">compression context</a><span>, in §3</span>
-   <li><a href="#compressionstream">CompressionStream</a><span>, in §5</span>
-   <li><a href="#dom-compressionstream-compressionstream">CompressionStream(format)</a><span>, in §5</span>
+   <li><a href="#compress-and-enqueue-a-chunk">compress and enqueue a chunk</a><span>, in § 5</span>
+   <li><a href="#compress-flush-and-enqueue">compress flush and enqueue</a><span>, in § 5</span>
+   <li><a href="#compression-context">compression context</a><span>, in § 3</span>
+   <li><a href="#compressionstream">CompressionStream</a><span>, in § 5</span>
+   <li><a href="#dom-compressionstream-compressionstream">CompressionStream(format)</a><span>, in § 5</span>
    <li>
     constructor(format)
     <ul>
-     <li><a href="#dom-compressionstream-compressionstream">constructor for CompressionStream</a><span>, in §5</span>
-     <li><a href="#dom-decompressionstream-decompressionstream">constructor for DecompressionStream</a><span>, in §6</span>
+     <li><a href="#dom-compressionstream-compressionstream">constructor for CompressionStream</a><span>, in § 5</span>
+     <li><a href="#dom-decompressionstream-decompressionstream">constructor for DecompressionStream</a><span>, in § 6</span>
     </ul>
    <li>
     context
     <ul>
-     <li><a href="#compressionstream-context">dfn for CompressionStream</a><span>, in §5</span>
-     <li><a href="#decompressionstream-context">dfn for DecompressionStream</a><span>, in §6</span>
+     <li><a href="#compressionstream-context">dfn for CompressionStream</a><span>, in § 5</span>
+     <li><a href="#decompressionstream-context">dfn for DecompressionStream</a><span>, in § 6</span>
     </ul>
-   <li><a href="#decompress-and-enqueue-a-chunk">decompress and enqueue a chunk</a><span>, in §6</span>
-   <li><a href="#decompress-flush-and-enqueue">decompress flush and enqueue</a><span>, in §6</span>
-   <li><a href="#decompressionstream">DecompressionStream</a><span>, in §6</span>
-   <li><a href="#dom-decompressionstream-decompressionstream">DecompressionStream(format)</a><span>, in §6</span>
+   <li><a href="#decompress-and-enqueue-a-chunk">decompress and enqueue a chunk</a><span>, in § 6</span>
+   <li><a href="#decompress-flush-and-enqueue">decompress flush and enqueue</a><span>, in § 6</span>
+   <li><a href="#decompressionstream">DecompressionStream</a><span>, in § 6</span>
+   <li><a href="#dom-decompressionstream-decompressionstream">DecompressionStream(format)</a><span>, in § 6</span>
    <li>
     format
     <ul>
-     <li><a href="#compressionstream-format">dfn for CompressionStream</a><span>, in §5</span>
-     <li><a href="#decompressionstream-format">dfn for DecompressionStream</a><span>, in §6</span>
+     <li><a href="#compressionstream-format">dfn for CompressionStream</a><span>, in § 5</span>
+     <li><a href="#decompressionstream-format">dfn for DecompressionStream</a><span>, in § 6</span>
     </ul>
   </ul>
   <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://heycam.github.io/webidl/#BufferSource">https://heycam.github.io/webidl/#BufferSource</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">3. Terminology</a>
     <li><a href="#ref-for-BufferSource①">5. Interface CompressionStream</a>
@@ -886,42 +1015,42 @@ specification uses that specification and terminology.</p>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5. Interface CompressionStream</a>
     <li><a href="#ref-for-idl-DOMString①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5. Interface CompressionStream</a>
     <li><a href="#ref-for-Exposed①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://heycam.github.io/webidl/#exceptiondef-typeerror">https://heycam.github.io/webidl/#exceptiondef-typeerror</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5. Interface CompressionStream</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">6. Interface DecompressionStream</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a> <a href="#ref-for-exceptiondef-typeerror④">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://heycam.github.io/webidl/#idl-Uint8Array">https://heycam.github.io/webidl/#idl-Uint8Array</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">5. Interface CompressionStream</a> <a href="#ref-for-idl-Uint8Array①">(2)</a> <a href="#ref-for-idl-Uint8Array②">(3)</a> <a href="#ref-for-idl-Uint8Array③">(4)</a>
     <li><a href="#ref-for-idl-Uint8Array④">6. Interface DecompressionStream</a> <a href="#ref-for-idl-Uint8Array⑤">(2)</a> <a href="#ref-for-idl-Uint8Array⑥">(3)</a> <a href="#ref-for-idl-Uint8Array⑦">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://heycam.github.io/webidl/#new">https://heycam.github.io/webidl/#new</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">5. Interface CompressionStream</a>
     <li><a href="#ref-for-new①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://heycam.github.io/webidl/#this">https://heycam.github.io/webidl/#this</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">5. Interface CompressionStream</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a>
     <li><a href="#ref-for-this⑤">6. Interface DecompressionStream</a> <a href="#ref-for-this⑥">(2)</a> <a href="#ref-for-this⑦">(3)</a> <a href="#ref-for-this⑧">(4)</a> <a href="#ref-for-this⑨">(5)</a>
@@ -1021,31 +1150,31 @@ specification uses that specification and terminology.</p>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-rfc1950">[RFC1950]
-   <dd>P. Deutsch; J-L. Gailly. <a href="https://datatracker.ietf.org/doc/html/rfc1950">ZLIB Compressed Data Format Specification version 3.3</a>. May 1996. Informational. URL: <a href="https://datatracker.ietf.org/doc/html/rfc1950">https://datatracker.ietf.org/doc/html/rfc1950</a>
+   <dd>P. Deutsch; J-L. Gailly. <a href="https://www.rfc-editor.org/rfc/rfc1950"><cite>ZLIB Compressed Data Format Specification version 3.3</cite></a>. May 1996. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc1950">https://www.rfc-editor.org/rfc/rfc1950</a>
    <dt id="biblio-rfc1952">[RFC1952]
-   <dd>P. Deutsch. <a href="https://datatracker.ietf.org/doc/html/rfc1952">GZIP file format specification version 4.3</a>. May 1996. Informational. URL: <a href="https://datatracker.ietf.org/doc/html/rfc1952">https://datatracker.ietf.org/doc/html/rfc1952</a>
+   <dd>P. Deutsch. <a href="https://www.rfc-editor.org/rfc/rfc1952"><cite>GZIP file format specification version 4.3</cite></a>. May 1996. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc1952">https://www.rfc-editor.org/rfc/rfc1952</a>
    <dt id="biblio-rfc2119">[RFC2119]
-   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/">Web IDL</a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
    <dt id="biblio-whatwg-streams">[WHATWG-STREAMS]
-   <dd>Adam Rice; Domenic Denicola; 吉野剛史 (Takeshi Yoshino). <a href="https://streams.spec.whatwg.org/">Streams Standard</a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
+   <dd>Adam Rice; et al. <a href="https://streams.spec.whatwg.org/"><cite>Streams Standard</cite></a>. Living Standard. URL: <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
    <dt id="biblio-rfc7230">[RFC7230]
-   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc7230.html">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7230.html">https://httpwg.org/specs/rfc7230.html</a>
+   <dd>R. Fielding, Ed.; J. Reschke, Ed.. <a href="https://httpwg.org/specs/rfc7230.html"><cite>Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</cite></a>. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7230.html">https://httpwg.org/specs/rfc7230.html</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a href="#compressionstream"><code><c- g>CompressionStream</c-></code></a> {
-  <a class="idl-code" data-link-type="constructor" href="#dom-compressionstream-compressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-compressionstream-compressionstream-format-format"><code><c- g>format</c-></code></a>);
+  <a class="idl-code" data-link-type="constructor" href="#dom-compressionstream-compressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-compressionstream-compressionstream-format-format"><code><c- g>format</c-></code></a>);
 };
 <a data-link-type="idl-name" href="#compressionstream"><c- n>CompressionStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream"><c- n>GenericTransformStream</c-></a>;
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=(<c- n>Window</c->,<c- n>Worker</c->)]
 <c- b>interface</c-> <a href="#decompressionstream"><code><c- g>DecompressionStream</c-></code></a> {
-  <a class="idl-code" data-link-type="constructor" href="#dom-decompressionstream-decompressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-decompressionstream-decompressionstream-format-format"><code><c- g>format</c-></code></a>);
+  <a class="idl-code" data-link-type="constructor" href="#dom-decompressionstream-decompressionstream"><c- g>constructor</c-></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <a href="#dom-decompressionstream-decompressionstream-format-format"><code><c- g>format</c-></code></a>);
 };
 <a data-link-type="idl-name" href="#decompressionstream"><c- n>DecompressionStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream"><c- n>GenericTransformStream</c-></a>;
 
@@ -1186,3 +1315,11 @@ document.body.addEventListener("click", function(e) {
 
 });
 </script>
+<script>/* script-mdn-anno */
+
+            document.body.addEventListener("click", (e) => {
+                if(e.target.closest(".mdn-anno-btn")) {
+                    e.target.closest(".mdn-anno").classList.toggle("wrapped");
+                }
+            });
+            </script>


### PR DESCRIPTION
Make the note about the use of "deflate" to refer to the "zlib" format
more prominent by rendering it as a note.

Also regenerate index.html, which has the side-effect of adding MDN
annotations.