### PR TITLE
Correct "decompressionStream" name in Gzip-decompress a Blob to Blob

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -69,7 +69,7 @@ A <dfn>compression context</dfn> is the internal state maintained by a compressi
 : `deflate`
 :: "ZLIB Compressed Data Format" [[!RFC1950]]
 
-   Note: This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See [[RFC7230]] section 4.2.2.
+   Note: This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See [[RFC7230 obsolete]] section 4.2.2.
 
    * Implementations must be "compliant" as described in [[!RFC1950]] section 2.3.
    * Field values described as invalid in [[!RFC1950]] must not be created by CompressionStream, and are errors for DecompressionStream.
@@ -219,7 +219,7 @@ async function compressArrayBuffer(input) {
 function decompressBlob(blob) {
   const ds = new DecompressionStream('gzip');
   const decompressionStream = blob.stream().pipeThrough(ds);
-  return new Response(decompressedStream).blob();
+  return new Response(decompressionStream).blob();
 }
 </pre>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title>Compression Streams</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version fb1e763a4, updated Tue Mar 1 13:13:50 2022 -0800" name="generator">
+  <meta content="Bikeshed version fe8c230, updated Wed Aug 10 08:18:38 2022 -0700" name="generator">
   <link href="https://wicg.github.io/compression/" rel="canonical">
 <style>/* style-autolinks */
 
@@ -632,7 +632,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Compression Streams</h1>
-   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-03-28">28 March 2022</time></p>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2022-08-15">15 August 2022</time></p>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -728,7 +728,7 @@ specification uses that specification and terminology.</p>
     <dt data-md><code>deflate</code>
     <dd data-md>
      <p>"ZLIB Compressed Data Format" <a data-link-type="biblio" href="#biblio-rfc1950">[RFC1950]</a></p>
-     <p class="note" role="note"><span>Note:</span> This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See <a data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> section 4.2.2.</p>
+     <p class="note" role="note"><span>Note:</span> This format is referred to as "deflate" for consistency with HTTP Content-Encodings. See <a data-biblio-obsolete data-link-type="biblio" href="#biblio-rfc7230">[RFC7230]</a> section 4.2.2.</p>
      <ul>
       <li data-md>
        <p>Implementations must be "compliant" as described in <a data-link-type="biblio" href="#biblio-rfc1950">[RFC1950]</a> section 2.3.</p>
@@ -789,11 +789,11 @@ specification uses that specification and terminology.</p>
      <div class="support">
       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
       <hr>
-      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
       <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <span class="edge no"><span>Edge (Legacy)</span><span>?</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>?</span></span><span class="webview_android no"><span>Android WebView</span><span>?</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>?</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
      </div>
     </div>
    </div>
@@ -812,13 +812,13 @@ specification uses that specification and terminology.</p>
      <div class="support">
       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
       <hr>
-      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
       <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <span class="edge no"><span>Edge (Legacy)</span><span>?</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>?</span></span><span class="webview_android no"><span>Android WebView</span><span>?</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>?</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
       <hr>
-      <span class="nodejs yes"><span>Node.js</span><span>16.7.0+</span></span>
+      <span class="nodejs yes"><span>Node.js</span><span>17.0.0+</span></span>
      </div>
     </div>
    </div>
@@ -870,11 +870,11 @@ specification uses that specification and terminology.</p>
      <div class="support">
       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
       <hr>
-      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
       <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <span class="edge no"><span>Edge (Legacy)</span><span>?</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>?</span></span><span class="webview_android no"><span>Android WebView</span><span>?</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>?</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
      </div>
     </div>
    </div>
@@ -893,13 +893,13 @@ specification uses that specification and terminology.</p>
      <div class="support">
       <span class="firefox no"><span>Firefox</span><span>None</span></span><span class="safari no"><span>Safari</span><span>None</span></span><span class="chrome yes"><span>Chrome</span><span>80+</span></span>
       <hr>
-      <span class="opera yes"><span>Opera</span><span>67+</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
+      <span class="opera no"><span>Opera</span><span>?</span></span><span class="edge_blink yes"><span>Edge</span><span>80+</span></span>
       <hr>
-      <span class="edge no"><span>Edge (Legacy)</span><span>None</span></span><span class="ie no"><span>IE</span><span>None</span></span>
+      <span class="edge no"><span>Edge (Legacy)</span><span>?</span></span><span class="ie no"><span>IE</span><span>None</span></span>
       <hr>
-      <span class="firefox_android no"><span>Firefox for Android</span><span>None</span></span><span class="safari_ios no"><span>iOS Safari</span><span>None</span></span><span class="chrome_android yes"><span>Chrome for Android</span><span>80+</span></span><span class="webview_android yes"><span>Android WebView</span><span>80+</span></span><span class="samsunginternet_android yes"><span>Samsung Internet</span><span>13.0+</span></span><span class="opera_android yes"><span>Opera Mobile</span><span>57+</span></span>
+      <span class="firefox_android no"><span>Firefox for Android</span><span>?</span></span><span class="safari_ios no"><span>iOS Safari</span><span>?</span></span><span class="chrome_android no"><span>Chrome for Android</span><span>?</span></span><span class="webview_android no"><span>Android WebView</span><span>?</span></span><span class="samsunginternet_android no"><span>Samsung Internet</span><span>?</span></span><span class="opera_android no"><span>Opera Mobile</span><span>?</span></span>
       <hr>
-      <span class="nodejs yes"><span>Node.js</span><span>16.7.0+</span></span>
+      <span class="nodejs yes"><span>Node.js</span><span>17.0.0+</span></span>
      </div>
     </div>
    </div>
@@ -978,10 +978,10 @@ specification uses that specification and terminology.</p>
 <c- p>}</c->
 </pre>
    <h3 class="heading settled" data-level="8.3" id="example-gzip-decompress"><span class="secno">8.3. </span><span class="content">Gzip-decompress a Blob to Blob</span><a class="self-link" href="#example-gzip-decompress"></a></h3>
-<pre class="example highlight" id="example-4d353c2c"><a class="self-link" href="#example-4d353c2c"></a><c- a>function</c-> decompressBlob<c- p>(</c->blob<c- p>)</c-> <c- p>{</c->
+<pre class="example highlight" id="example-f0a2126d"><a class="self-link" href="#example-f0a2126d"></a><c- a>function</c-> decompressBlob<c- p>(</c->blob<c- p>)</c-> <c- p>{</c->
   <c- a>const</c-> ds <c- o>=</c-> <c- ow>new</c-> DecompressionStream<c- p>(</c-><c- t>'gzip'</c-><c- p>);</c->
   <c- a>const</c-> decompressionStream <c- o>=</c-> blob<c- p>.</c->stream<c- p>().</c->pipeThrough<c- p>(</c->ds<c- p>);</c->
-  <c- k>return</c-> <c- ow>new</c-> Response<c- p>(</c->decompressedStream<c- p>).</c->blob<c- p>();</c->
+  <c- k>return</c-> <c- ow>new</c-> Response<c- p>(</c->decompressionStream<c- p>).</c->blob<c- p>();</c->
 <c- p>}</c->
 </pre>
    <h2 class="heading settled" data-level="9" id="acknowledgments"><span class="secno">9. </span><span class="content">Acknowledgments</span><a class="self-link" href="#acknowledgments"></a></h2>


### PR DESCRIPTION
This change corrects a small spelling issue in Gzip-decompress a Blob to
Blob example, and adds an obsolete qualifier to the RFC7230 tag to ensure
the document compiles.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 16, 2022, 12:59 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fcompression%2F6d344f764d6fe03a67e8fbf804b960dee336686b%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Obsolete biblio ref: [rfc7230] is replaced by [rfc9112]. Either update the reference, or use [rfc7230 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/compression%2345.)._
</details>
